### PR TITLE
feat: add autonomous oanda trading agent

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,30 @@ This project is a deployable starter kit for easily building and customizing you
 The primary goal of this project, beyond just being a lot of fun to work on, is to provide a platform with a strong foundation that is meant to be extended. The back-end engine natively supports shared global state, transactions, and a journal of all events so should be suitable for everything from a simple project to play around with to a scalable, multi-player game. A secondary goal is to make a JS/TS framework available as most simulators in this space (including the original paper above) are written in Python.
 
 
+## Autonomous OANDA Crypto Trader
+
+In addition to the social simulation, AI Town now ships with an autonomous crypto trading agent that integrates directly with [OANDA](https://www.oanda.com/). The trader runs entirely inside Convex using scheduled evaluations and can be controlled from the **Trader** dashboard at `/trader`.
+
+**Highlights**
+
+- Momentum-based strategy with configurable moving averages, stop loss and take profit multipliers.
+- Automatic order execution through OANDA practice or live accounts.
+- Rich activity log, manual tick triggering, and optional flatting of open positions on stop.
+
+### Broker configuration
+
+Add the following environment variables to your Convex deployment (or `.env.local`) before starting a session:
+
+```
+OANDA_API_KEY=your-rest-token
+OANDA_ACCOUNT_ID=your-account-id
+# Optional: override base URL (defaults to the OANDA practice API)
+OANDA_API_URL=https://api-fxpractice.oanda.com/v3
+```
+
+Once configured, visit `/trader`, create a session, and click **Start** to let the agent trade autonomously. The backend evaluates active sessions every minute via a Convex cron job.
+
+
 ## Overview
 
 - 💻 [Stack](#stack)

--- a/convex/_generated/api.d.ts
+++ b/convex/_generated/api.d.ts
@@ -38,6 +38,7 @@ import type * as journal from "../journal";
 import type * as lib_cached_llm from "../lib/cached_llm";
 import type * as lib_memory from "../lib/memory";
 import type * as lib_migrations from "../lib/migrations";
+import type * as lib_oanda from "../lib/oanda";
 import type * as lib_openai from "../lib/openai";
 import type * as lib_physics from "../lib/physics";
 import type * as lib_pinecone from "../lib/pinecone";
@@ -46,6 +47,7 @@ import type * as lib_utils from "../lib/utils";
 import type * as maps_firstmap from "../maps/firstmap";
 import type * as players from "../players";
 import type * as testing from "../testing";
+import type * as trader from "../trader";
 
 /**
  * A utility for referencing Convex functions in your app's API.
@@ -80,6 +82,7 @@ declare const fullApi: ApiFromModules<{
   "lib/cached_llm": typeof lib_cached_llm;
   "lib/memory": typeof lib_memory;
   "lib/migrations": typeof lib_migrations;
+  "lib/oanda": typeof lib_oanda;
   "lib/openai": typeof lib_openai;
   "lib/physics": typeof lib_physics;
   "lib/pinecone": typeof lib_pinecone;
@@ -88,6 +91,7 @@ declare const fullApi: ApiFromModules<{
   "maps/firstmap": typeof maps_firstmap;
   players: typeof players;
   testing: typeof testing;
+  trader: typeof trader;
 }>;
 export declare const api: FilterApi<
   typeof fullApi,

--- a/convex/crons.ts
+++ b/convex/crons.ts
@@ -159,4 +159,5 @@ crons.interval('vacuum old memory entries', { hours: 6 }, internal.crons.vacuumO
   cursor: null,
   soFar: 0,
 });
+crons.interval('evaluate trading sessions', { minutes: 1 }, internal.trader.tickActiveSessions, {});
 export default crons;

--- a/convex/lib/oanda.ts
+++ b/convex/lib/oanda.ts
@@ -1,0 +1,157 @@
+const DEFAULT_BASE_URL = 'https://api-fxpractice.oanda.com/v3';
+
+function baseUrl() {
+  return (process.env.OANDA_API_URL || DEFAULT_BASE_URL).replace(/\/$/, '');
+}
+
+function requireApiKey(): string {
+  const key = process.env.OANDA_API_KEY;
+  if (!key) {
+    throw new Error(
+      'Missing OANDA_API_KEY environment variable. Set it to your OANDA REST API token to enable live trading.',
+    );
+  }
+  return key;
+}
+
+function requireAccountId(): string {
+  const accountId = process.env.OANDA_ACCOUNT_ID;
+  if (!accountId) {
+    throw new Error(
+      'Missing OANDA_ACCOUNT_ID environment variable. Set it to the practice or live account you wish to trade.',
+    );
+  }
+  return accountId;
+}
+
+export function isOandaConfigured() {
+  return !!process.env.OANDA_API_KEY && !!process.env.OANDA_ACCOUNT_ID;
+}
+
+async function oandaFetch<T = any>(path: string, init: RequestInit = {}): Promise<T> {
+  const apiKey = requireApiKey();
+  const headers = new Headers(init.headers || undefined);
+  headers.set('Authorization', `Bearer ${apiKey}`);
+  if (!headers.has('Content-Type') && init.body) {
+    headers.set('Content-Type', 'application/json');
+  }
+  const response = await fetch(`${baseUrl()}${path}`, { ...init, headers });
+  if (!response.ok) {
+    const text = await response.text();
+    throw new Error(`OANDA request failed (${response.status} ${response.statusText}): ${text}`);
+  }
+  if (response.status === 204) {
+    return undefined as T;
+  }
+  return (await response.json()) as T;
+}
+
+export interface OandaCandle {
+  complete: boolean;
+  volume: number;
+  time: string;
+  mid: {
+    o: string;
+    h: string;
+    l: string;
+    c: string;
+  };
+}
+
+export async function fetchCandles({
+  instrument,
+  granularity,
+  count,
+  price = 'M',
+}: {
+  instrument: string;
+  granularity: string;
+  count: number;
+  price?: 'M' | 'B' | 'A';
+}): Promise<OandaCandle[]> {
+  const searchParams = new URLSearchParams({
+    price,
+    granularity,
+    count: Math.min(5000, Math.max(1, count)).toString(),
+  });
+  const result = await oandaFetch<{ candles: OandaCandle[] }>(
+    `/instruments/${instrument}/candles?${searchParams.toString()}`,
+  );
+  return result.candles ?? [];
+}
+
+export interface OandaOrderFill {
+  price?: string;
+  fullPrice?: {
+    price: string;
+  };
+  pl?: string;
+  tradeOpened?: { tradeID: string; units: string };
+  tradesOpened?: { tradeID: string; units: string }[];
+  tradeReduced?: { tradeID: string; units: string };
+  tradesClosed?: { tradeID: string; units: string }[];
+}
+
+export interface OandaOrderResponse {
+  orderCreateTransaction?: Record<string, any>;
+  orderFillTransaction?: OandaOrderFill;
+  orderFillTransactions?: OandaOrderFill[];
+  relatedTransactionIDs?: string[];
+  lastTransactionID?: string;
+}
+
+export async function placeMarketOrder({
+  instrument,
+  units,
+  takeProfitPrice,
+  stopLossPrice,
+}: {
+  instrument: string;
+  units: number;
+  takeProfitPrice?: number;
+  stopLossPrice?: number;
+}): Promise<OandaOrderResponse> {
+  const accountId = requireAccountId();
+  const body: Record<string, any> = {
+    order: {
+      instrument,
+      units: units.toString(),
+      timeInForce: 'FOK',
+      type: 'MARKET',
+      positionFill: 'DEFAULT',
+    },
+  };
+  if (takeProfitPrice) {
+    body.order.takeProfitOnFill = { price: takeProfitPrice.toFixed(5) };
+  }
+  if (stopLossPrice) {
+    body.order.stopLossOnFill = { price: stopLossPrice.toFixed(5) };
+  }
+  return await oandaFetch<OandaOrderResponse>(`/accounts/${accountId}/orders`, {
+    method: 'POST',
+    body: JSON.stringify(body),
+  });
+}
+
+export async function closeTrade(tradeId: string): Promise<OandaOrderResponse> {
+  const accountId = requireAccountId();
+  return await oandaFetch<OandaOrderResponse>(`/accounts/${accountId}/trades/${tradeId}/close`, {
+    method: 'PUT',
+    body: JSON.stringify({ units: 'ALL' }),
+  });
+}
+
+export interface OandaTrade {
+  id?: string;
+  tradeID?: string;
+  instrument: string;
+  price: string;
+  currentUnits: string;
+  unrealizedPL?: string;
+}
+
+export async function getOpenTrades(): Promise<OandaTrade[]> {
+  const accountId = requireAccountId();
+  const result = await oandaFetch<{ trades: OandaTrade[] }>(`/accounts/${accountId}/openTrades`);
+  return result.trades ?? [];
+}

--- a/convex/trader.ts
+++ b/convex/trader.ts
@@ -1,0 +1,664 @@
+import { Infer, v } from 'convex/values';
+import { Doc, Id } from './_generated/dataModel';
+import {
+  ActionCtx,
+  internalAction,
+  internalMutation,
+  internalQuery,
+  mutation,
+  query,
+} from './_generated/server';
+import { internal } from './_generated/api';
+import {
+  TraderLog,
+  TraderLogs,
+  TraderPosition,
+  TraderPositions,
+  TraderSession,
+  TraderSessions,
+} from './schema';
+import {
+  closeTrade,
+  fetchCandles,
+  getOpenTrades,
+  isOandaConfigured,
+  placeMarketOrder,
+  OandaOrderResponse,
+} from './lib/oanda';
+
+const sessionConfigFields = {
+  name: v.string(),
+  instrument: v.string(),
+  granularity: v.string(),
+  shortWindow: v.number(),
+  longWindow: v.number(),
+  tradeUnits: v.number(),
+  takeProfitMultiplier: v.number(),
+  stopLossMultiplier: v.number(),
+  neutralThreshold: v.number(),
+};
+const sessionConfigValidator = v.object(sessionConfigFields);
+
+const logLevelValidator = TraderLogs.fields.level;
+const directionValidator = TraderPositions.fields.direction;
+const statusValidator = TraderSessions.fields.status;
+const signalValidator = TraderSessions.fields.lastSignal;
+
+type LogLevel = TraderLog['level'];
+type TradingDirection = TraderPosition['direction'];
+type TradingSignal = TraderSession['lastSignal'];
+type SessionConfig = Infer<typeof sessionConfigValidator>;
+
+function requireSession(session: TraderSession | null, sessionId: Id<'traderSessions'>) {
+  if (!session) {
+    throw new Error(`Trader session ${sessionId} not found`);
+  }
+  return session;
+}
+
+export const listSessions = query({
+  args: {},
+  handler: async (ctx) => {
+    return await ctx.db.query('traderSessions').order('desc').collect();
+  },
+});
+
+export const sessionById = query({
+  args: { sessionId: v.id('traderSessions') },
+  handler: async (ctx, args) => {
+    return await ctx.db.get(args.sessionId);
+  },
+});
+
+export const listLogs = query({
+  args: {
+    sessionId: v.optional(v.id('traderSessions')),
+    limit: v.optional(v.number()),
+  },
+  handler: async (ctx, args) => {
+    const sessionId = args.sessionId;
+    if (!sessionId) return [];
+    const limit = Math.min(500, Math.max(1, args.limit ?? 100));
+    return await ctx.db
+      .query('traderLogs')
+      .withIndex('by_sessionId', (q) => q.eq('sessionId', sessionId))
+      .order('desc')
+      .take(limit);
+  },
+});
+
+export const listPositions = query({
+  args: { sessionId: v.optional(v.id('traderSessions')) },
+  handler: async (ctx, args) => {
+    const sessionId = args.sessionId;
+    if (!sessionId) return [];
+    return await ctx.db
+      .query('traderPositions')
+      .withIndex('by_session', (q) => q.eq('sessionId', sessionId))
+      .order('desc')
+      .collect();
+  },
+});
+
+export const createSession = mutation({
+  args: sessionConfigFields,
+  handler: async (ctx, args: SessionConfig) => {
+    validateConfig(args);
+    const now = Date.now();
+    const sessionId = await ctx.db.insert('traderSessions', {
+      ...args,
+      status: 'stopped',
+      lastSignal: 'neutral',
+      createdAt: now,
+      updatedAt: now,
+    });
+    await ctx.db.insert('traderLogs', {
+      sessionId,
+      level: 'info',
+      message: `Created trading session for ${args.instrument} (${args.granularity})`,
+      createdAt: now,
+    });
+    return sessionId;
+  },
+});
+
+export const updateSession = mutation({
+  args: {
+    sessionId: v.id('traderSessions'),
+    config: sessionConfigValidator,
+  },
+  handler: async (ctx, { sessionId, config }) => {
+    validateConfig(config);
+    const now = Date.now();
+    await ctx.db.patch(sessionId, { ...config, updatedAt: now });
+    await ctx.db.insert('traderLogs', {
+      sessionId,
+      level: 'info',
+      message: `Updated configuration for ${config.instrument}`,
+      createdAt: now,
+    });
+  },
+});
+
+export const startSession = mutation({
+  args: { sessionId: v.id('traderSessions') },
+  handler: async (ctx, { sessionId }) => {
+    const session = requireSession(await ctx.db.get(sessionId), sessionId);
+    if (session.status === 'running') return;
+    const now = Date.now();
+    await ctx.db.patch(sessionId, {
+      status: 'running',
+      updatedAt: now,
+      errorMessage: undefined,
+    });
+    await ctx.db.insert('traderLogs', {
+      sessionId,
+      level: 'info',
+      message: 'Trading session started',
+      createdAt: now,
+    });
+    await ctx.scheduler.runAfter(0, internal.trader.evaluateSession, {
+      sessionId,
+      reason: 'manual-start',
+    });
+  },
+});
+
+export const stopSession = mutation({
+  args: {
+    sessionId: v.id('traderSessions'),
+    closePositions: v.optional(v.boolean()),
+  },
+  handler: async (ctx, { sessionId, closePositions }) => {
+    const session = requireSession(await ctx.db.get(sessionId), sessionId);
+    const now = Date.now();
+    await ctx.db.patch(sessionId, {
+      status: 'stopped',
+      updatedAt: now,
+      errorMessage: undefined,
+    });
+    await ctx.db.insert('traderLogs', {
+      sessionId,
+      level: 'info',
+      message: 'Trading session stopped',
+      createdAt: now,
+    });
+    if (closePositions ?? true) {
+      await ctx.scheduler.runAfter(0, internal.trader.closeSessionPositions, {
+        sessionId: session._id,
+        reason: 'manual-stop',
+      });
+    }
+  },
+});
+
+export const requestImmediateTick = mutation({
+  args: { sessionId: v.id('traderSessions') },
+  handler: async (ctx, { sessionId }) => {
+    requireSession(await ctx.db.get(sessionId), sessionId);
+    const now = Date.now();
+    await ctx.db.insert('traderLogs', {
+      sessionId,
+      level: 'info',
+      message: 'Manual tick requested',
+      createdAt: now,
+    });
+    await ctx.scheduler.runAfter(0, internal.trader.evaluateSession, {
+      sessionId,
+      reason: 'manual-tick',
+    });
+  },
+});
+
+export const getSessionState = internalQuery({
+  args: { sessionId: v.id('traderSessions') },
+  handler: async (ctx, { sessionId }) => {
+    const session = await ctx.db.get(sessionId);
+    if (!session) return null;
+    const openPositions = await ctx.db
+      .query('traderPositions')
+      .withIndex('by_session_status', (q) =>
+        q.eq('sessionId', sessionId).eq('status', 'open'),
+      )
+      .collect();
+    return { session, openPositions };
+  },
+});
+
+export const getActiveSessionIds = internalQuery({
+  args: {},
+  handler: async (ctx) => {
+    const sessions = await ctx.db
+      .query('traderSessions')
+      .withIndex('by_status', (q) => q.eq('status', 'running'))
+      .collect();
+    return sessions.map((session) => session._id);
+  },
+});
+
+export const logEvent = internalMutation({
+  args: {
+    sessionId: v.id('traderSessions'),
+    level: logLevelValidator,
+    message: v.string(),
+    details: v.optional(v.any()),
+  },
+  handler: async (ctx, args) => {
+    await ctx.db.insert('traderLogs', {
+      sessionId: args.sessionId,
+      level: args.level,
+      message: args.message,
+      details: args.details,
+      createdAt: Date.now(),
+    });
+  },
+});
+
+export const updateAnalytics = internalMutation({
+  args: {
+    sessionId: v.id('traderSessions'),
+    lastShortMA: v.optional(v.number()),
+    lastLongMA: v.optional(v.number()),
+    lastPrice: v.optional(v.number()),
+    lastSignal: v.optional(signalValidator),
+    lastEvaluationTime: v.optional(v.number()),
+    errorMessage: v.optional(v.string()),
+  },
+  handler: async (ctx, args) => {
+    const patch: Partial<TraderSession> = {
+      updatedAt: Date.now(),
+    };
+    if (args.lastShortMA !== undefined) patch.lastShortMA = args.lastShortMA;
+    if (args.lastLongMA !== undefined) patch.lastLongMA = args.lastLongMA;
+    if (args.lastPrice !== undefined) patch.lastPrice = args.lastPrice;
+    if (args.lastSignal !== undefined) patch.lastSignal = args.lastSignal;
+    if (args.lastEvaluationTime !== undefined)
+      patch.lastEvaluationTime = args.lastEvaluationTime;
+    if (args.errorMessage !== undefined) patch.errorMessage = args.errorMessage;
+    await ctx.db.patch(args.sessionId, patch);
+  },
+});
+
+export const setStatus = internalMutation({
+  args: {
+    sessionId: v.id('traderSessions'),
+    status: statusValidator,
+    errorMessage: v.optional(v.string()),
+  },
+  handler: async (ctx, args) => {
+    const patch: Partial<TraderSession> = {
+      status: args.status,
+      updatedAt: Date.now(),
+    };
+    if (args.errorMessage !== undefined) {
+      patch.errorMessage = args.errorMessage;
+    }
+    await ctx.db.patch(args.sessionId, patch);
+  },
+});
+
+export const createPositionRecord = internalMutation({
+  args: {
+    sessionId: v.id('traderSessions'),
+    direction: directionValidator,
+    units: v.number(),
+    entryPrice: v.number(),
+    takeProfitPrice: v.optional(v.number()),
+    stopLossPrice: v.optional(v.number()),
+    oandaTradeId: v.optional(v.string()),
+  },
+  handler: async (ctx, args) => {
+    await ctx.db.insert('traderPositions', {
+      sessionId: args.sessionId,
+      direction: args.direction,
+      units: args.units,
+      entryPrice: args.entryPrice,
+      takeProfitPrice: args.takeProfitPrice,
+      stopLossPrice: args.stopLossPrice,
+      status: 'open',
+      oandaTradeId: args.oandaTradeId,
+      openedAt: Date.now(),
+    });
+    await ctx.db.patch(args.sessionId, { updatedAt: Date.now() });
+  },
+});
+
+export const closePositionRecord = internalMutation({
+  args: {
+    positionId: v.id('traderPositions'),
+    exitPrice: v.optional(v.number()),
+    realizedPnl: v.optional(v.number()),
+    closeReason: v.string(),
+  },
+  handler: async (ctx, args) => {
+    const position = await ctx.db.get(args.positionId);
+    if (!position) return;
+    const patch: Partial<TraderPosition> = {
+      status: 'closed',
+      closedAt: Date.now(),
+      closeReason: args.closeReason,
+    };
+    if (args.exitPrice !== undefined) patch.exitPrice = args.exitPrice;
+    if (args.realizedPnl !== undefined) patch.realizedPnl = args.realizedPnl;
+    await ctx.db.patch(args.positionId, patch);
+    await ctx.db.patch(position.sessionId, { updatedAt: Date.now() });
+  },
+});
+
+export const closeSessionPositions = internalAction({
+  args: {
+    sessionId: v.id('traderSessions'),
+    reason: v.optional(v.string()),
+  },
+  handler: async (ctx, args) => {
+    const state = await ctx.runQuery(internal.trader.getSessionState, {
+      sessionId: args.sessionId,
+    });
+    if (!state) return;
+    const { session, openPositions } = state;
+    for (const position of openPositions) {
+      await closePositionWithBroker(ctx, session, position, session.lastPrice ?? position.entryPrice, args.reason ?? 'manual');
+    }
+  },
+});
+
+export const tickActiveSessions = internalAction({
+  args: {},
+  handler: async (ctx) => {
+    const sessionIds = await ctx.runQuery(internal.trader.getActiveSessionIds, {});
+    for (const sessionId of sessionIds) {
+      await ctx.runAction(internal.trader.evaluateSession, { sessionId });
+    }
+  },
+});
+
+export const evaluateSession = internalAction({
+  args: {
+    sessionId: v.id('traderSessions'),
+    reason: v.optional(v.string()),
+  },
+  handler: async (ctx, args) => {
+    const state = await ctx.runQuery(internal.trader.getSessionState, {
+      sessionId: args.sessionId,
+    });
+    if (!state) return;
+    const { session } = state;
+    if (session.status !== 'running') {
+      return;
+    }
+
+    const log = (level: LogLevel, message: string, details?: Record<string, any>) =>
+      ctx.runMutation(internal.trader.logEvent, {
+        sessionId: session._id,
+        level,
+        message,
+        details,
+      });
+
+    try {
+      const maxLookback = Math.max(session.longWindow * 2, session.longWindow + 5);
+      const candles = await fetchCandles({
+        instrument: session.instrument,
+        granularity: session.granularity,
+        count: maxLookback,
+      });
+      const completedCandles = candles.filter((candle) => candle.complete);
+      const closes = completedCandles.map((candle) => parseFloat(candle.mid.c));
+      if (closes.length < session.longWindow) {
+        await log(
+          'warn',
+          `Not enough historical candles to evaluate strategy (have ${closes.length}, need ${session.longWindow})`,
+        );
+        return;
+      }
+      const shortMA = movingAverage(closes, session.shortWindow);
+      const longMA = movingAverage(closes, session.longWindow);
+      const latestPrice = closes[closes.length - 1];
+      const previousSignal: TradingSignal = session.lastSignal ?? 'neutral';
+      const signal = computeSignal(shortMA, longMA, session.neutralThreshold);
+
+      await ctx.runMutation(internal.trader.updateAnalytics, {
+        sessionId: session._id,
+        lastShortMA: shortMA,
+        lastLongMA: longMA,
+        lastPrice: latestPrice,
+        lastSignal: signal,
+        lastEvaluationTime: Date.now(),
+        errorMessage: undefined,
+      });
+
+      await log('analysis', 'Tick processed', {
+        shortMA,
+        longMA,
+        latestPrice,
+        signal,
+        previousSignal,
+        reason: args.reason ?? 'scheduled',
+      });
+
+      let openPositions = state.openPositions;
+      if (openPositions.length && isOandaConfigured()) {
+        try {
+          const liveTrades = await getOpenTrades();
+          const liveIds = new Set(
+            liveTrades.map((trade) => trade.id ?? trade.tradeID ?? ''),
+          );
+          for (const position of openPositions) {
+            if (position.oandaTradeId && !liveIds.has(position.oandaTradeId)) {
+              await ctx.runMutation(internal.trader.closePositionRecord, {
+                positionId: position._id,
+                exitPrice: latestPrice,
+                closeReason: 'broker-closed',
+              });
+              await log('trade', 'Detected broker-closed position', {
+                positionId: position._id,
+                tradeId: position.oandaTradeId,
+              });
+            }
+          }
+          openPositions = await ctx.runQuery(internal.trader.getSessionState, {
+            sessionId: session._id,
+          }).then((s) => s?.openPositions ?? []);
+        } catch (error) {
+          await log('warn', `Failed to sync open trades: ${formatError(error)}`);
+        }
+      }
+
+      const activePosition = openPositions[0];
+      if (activePosition) {
+        if (signal === 'neutral' || signal !== activePosition.direction) {
+          await log('info', 'Signal requires closing current position', {
+            signal,
+            activeDirection: activePosition.direction,
+          });
+          await closePositionWithBroker(
+            ctx,
+            session,
+            activePosition,
+            latestPrice,
+            signal === 'neutral' ? 'neutral-signal' : 'signal-flip',
+          );
+          openPositions = await ctx.runQuery(internal.trader.getSessionState, {
+            sessionId: session._id,
+          }).then((s) => s?.openPositions ?? []);
+        }
+      }
+
+      if (!openPositions.length && signal !== 'neutral' && signal !== previousSignal) {
+        await log('info', 'Attempting to open new position', { signal });
+        await openPositionWithBroker(ctx, session, signal, latestPrice);
+      }
+    } catch (error) {
+      const message = formatError(error);
+      await ctx.runMutation(internal.trader.logEvent, {
+        sessionId: session._id,
+        level: 'error',
+        message: `Evaluation failed: ${message}`,
+      });
+      await ctx.runMutation(internal.trader.setStatus, {
+        sessionId: session._id,
+        status: 'error',
+        errorMessage: message,
+      });
+    }
+  },
+});
+
+function validateConfig(config: SessionConfig) {
+  if (config.longWindow <= config.shortWindow) {
+    throw new Error('Long window must be greater than short window.');
+  }
+  if (config.tradeUnits <= 0) {
+    throw new Error('Trade units must be greater than zero.');
+  }
+  if (config.takeProfitMultiplier <= 0 || config.stopLossMultiplier <= 0) {
+    throw new Error('Take profit and stop loss multipliers must be positive numbers.');
+  }
+  if (config.neutralThreshold < 0) {
+    throw new Error('Neutral threshold must be zero or positive.');
+  }
+}
+
+function movingAverage(series: number[], length: number) {
+  if (series.length < length) {
+    return series[series.length - 1];
+  }
+  const window = series.slice(series.length - length);
+  const sum = window.reduce((acc, value) => acc + value, 0);
+  return sum / window.length;
+}
+
+function computeSignal(
+  shortMA: number,
+  longMA: number,
+  neutralThreshold: number,
+): TradingSignal {
+  const diff = shortMA - longMA;
+  if (Math.abs(longMA) < Number.EPSILON) {
+    return diff > 0 ? 'long' : diff < 0 ? 'short' : 'neutral';
+  }
+  const ratio = Math.abs(diff) / Math.abs(longMA);
+  if (ratio < neutralThreshold) {
+    return 'neutral';
+  }
+  return diff > 0 ? 'long' : 'short';
+}
+
+function extractTradeId(response: OandaOrderResponse): string | undefined {
+  const fill = response.orderFillTransaction ?? response.orderFillTransactions?.[0];
+  if (!fill) return undefined;
+  if (fill.tradeOpened?.tradeID) return fill.tradeOpened.tradeID;
+  if (fill.tradesOpened && fill.tradesOpened.length > 0) {
+    return fill.tradesOpened[0].tradeID;
+  }
+  if (fill.tradeReduced?.tradeID) return fill.tradeReduced.tradeID;
+  if (fill.tradesClosed && fill.tradesClosed.length > 0) {
+    return fill.tradesClosed[0].tradeID;
+  }
+  return undefined;
+}
+
+async function openPositionWithBroker(
+  ctx: ActionCtx,
+  session: TraderSession,
+  signal: Exclude<TradingSignal, 'neutral'>,
+  marketPrice: number,
+) {
+  const direction: TradingDirection = signal;
+  const units = Math.abs(session.tradeUnits) * (direction === 'long' ? 1 : -1);
+  const takeProfitPrice =
+    direction === 'long'
+      ? marketPrice * (1 + session.takeProfitMultiplier)
+      : marketPrice * (1 - session.takeProfitMultiplier);
+  const stopLossPrice =
+    direction === 'long'
+      ? marketPrice * (1 - session.stopLossMultiplier)
+      : marketPrice * (1 + session.stopLossMultiplier);
+
+  let tradeId: string | undefined;
+  let entryPrice = marketPrice;
+  if (isOandaConfigured()) {
+    const response = await placeMarketOrder({
+      instrument: session.instrument,
+      units,
+      takeProfitPrice,
+      stopLossPrice,
+    });
+    tradeId = extractTradeId(response);
+    const fill = response.orderFillTransaction ?? response.orderFillTransactions?.[0];
+    if (fill?.price) {
+      entryPrice = parseFloat(fill.price);
+    } else if (fill?.fullPrice?.price) {
+      entryPrice = parseFloat(fill.fullPrice.price);
+    }
+  }
+
+  await ctx.runMutation(internal.trader.createPositionRecord, {
+    sessionId: session._id,
+    direction,
+    units,
+    entryPrice,
+    takeProfitPrice,
+    stopLossPrice,
+    oandaTradeId: tradeId,
+  });
+  await ctx.runMutation(internal.trader.logEvent, {
+    sessionId: session._id,
+    level: 'trade',
+    message: `Opened ${direction.toUpperCase()} position (${units} units)`,
+    details: {
+      tradeId,
+      entryPrice,
+      takeProfitPrice,
+      stopLossPrice,
+    },
+  });
+}
+
+async function closePositionWithBroker(
+  ctx: ActionCtx,
+  session: TraderSession,
+  position: Doc<'traderPositions'>,
+  marketPrice: number,
+  reason: string,
+) {
+  let exitPrice = marketPrice;
+  let realizedPnl: number | undefined;
+  if (position.oandaTradeId && isOandaConfigured()) {
+    const response = await closeTrade(position.oandaTradeId);
+    const fill = response.orderFillTransaction ?? response.orderFillTransactions?.[0];
+    if (fill?.price) {
+      exitPrice = parseFloat(fill.price);
+    } else if (fill?.fullPrice?.price) {
+      exitPrice = parseFloat(fill.fullPrice.price);
+    }
+    if (fill?.pl) {
+      realizedPnl = parseFloat(fill.pl);
+    }
+  }
+  await ctx.runMutation(internal.trader.closePositionRecord, {
+    positionId: position._id,
+    exitPrice,
+    realizedPnl,
+    closeReason: reason,
+  });
+  await ctx.runMutation(internal.trader.logEvent, {
+    sessionId: session._id,
+    level: 'trade',
+    message: `Closed position ${position._id} (${reason})`,
+    details: {
+      tradeId: position.oandaTradeId,
+      exitPrice,
+      realizedPnl,
+    },
+  });
+}
+
+function formatError(error: unknown) {
+  if (error instanceof Error) return error.message;
+  try {
+    return JSON.stringify(error);
+  } catch {
+    return String(error);
+  }
+}

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,4 +1,5 @@
-import { SignedIn, SignedOut, UserButton, auth } from '@clerk/nextjs';
+import { SignedIn, SignedOut, UserButton } from '@clerk/nextjs';
+import Link from 'next/link';
 import GameWrapper from '@/components/GameWrapper';
 import FreezeButton from '@/components/FreezeButton';
 import LoginButton from '@/components/LoginButton';
@@ -24,6 +25,13 @@ export default function Home() {
         <p className="mx-auto my-4 text-center text-xl sm:text-2xl text-white leading-tight shadow-solid">
           A virtual town where AI characters live, chat and socialize.
         </p>
+
+        <Link
+          href="/trader"
+          className="inline-flex items-center gap-3 px-6 py-3 mt-2 text-lg text-white border border-clay-500 rounded-xl bg-clay-800/80 hover:bg-clay-700 transition"
+        >
+          🚀 Launch the Autonomous OANDA Trader
+        </Link>
 
         <GameWrapper />
 

--- a/src/app/trader/page.tsx
+++ b/src/app/trader/page.tsx
@@ -1,0 +1,38 @@
+import { SignedIn, SignedOut, UserButton } from '@clerk/nextjs';
+import Link from 'next/link';
+import TraderDashboard from '@/components/trader/TraderDashboard';
+import LoginButton from '@/components/LoginButton';
+
+export const metadata = {
+  title: 'Autonomous OANDA Crypto Trader',
+  description:
+    'Configure and run a fully autonomous crypto trading agent that executes on the OANDA platform.',
+};
+
+export default function TraderPage() {
+  return (
+    <main className="relative flex min-h-screen flex-col items-center justify-between font-body game-background">
+      <div className="p-6 absolute top-0 right-0 z-10 text-2xl">
+        <SignedIn>
+          <UserButton afterSignOutUrl="/" />
+        </SignedIn>
+        <SignedOut>
+          <LoginButton />
+        </SignedOut>
+      </div>
+
+      <div className="w-full min-h-screen relative isolate overflow-hidden p-6 lg:p-8 shadow-2xl flex flex-col gap-6">
+        <div className="flex items-center justify-between text-white">
+          <Link href="/" className="text-sm text-clay-200 hover:text-white underline decoration-dotted">
+            ← Back to AI Town
+          </Link>
+          <div className="text-right text-xs text-clay-200">
+            <p>Requires OANDA API credentials to execute live orders.</p>
+            <p>Set OANDA_API_KEY and OANDA_ACCOUNT_ID in Convex env variables.</p>
+          </div>
+        </div>
+        <TraderDashboard />
+      </div>
+    </main>
+  );
+}

--- a/src/components/trader/TraderDashboard.tsx
+++ b/src/components/trader/TraderDashboard.tsx
@@ -1,0 +1,497 @@
+'use client';
+
+import { ChangeEvent, FormEvent, HTMLInputTypeAttribute, useEffect, useMemo, useState } from 'react';
+import { useMutation, useQuery } from 'convex/react';
+import { api } from '../../../convex/_generated/api';
+import { Doc, Id } from '../../../convex/_generated/dataModel';
+
+const defaultForm = {
+  name: 'Crypto Momentum Agent',
+  instrument: 'BTC_USD',
+  granularity: 'M5',
+  shortWindow: 9,
+  longWindow: 21,
+  tradeUnits: 1,
+  takeProfitMultiplier: 0.01,
+  stopLossMultiplier: 0.005,
+  neutralThreshold: 0.0005,
+};
+
+type FormState = typeof defaultForm;
+type SessionDoc = Doc<'traderSessions'>;
+type PositionDoc = Doc<'traderPositions'>;
+type LogDoc = Doc<'traderLogs'>;
+
+const numericFields: (keyof FormState)[] = [
+  'shortWindow',
+  'longWindow',
+  'tradeUnits',
+  'takeProfitMultiplier',
+  'stopLossMultiplier',
+  'neutralThreshold',
+];
+
+const actionButtonClasses =
+  'inline-flex items-center px-4 py-2 rounded-lg border border-clay-600 bg-clay-800/80 text-white hover:bg-clay-700 transition disabled:opacity-60 disabled:cursor-not-allowed';
+
+export default function TraderDashboard() {
+  const sessions = useQuery(api.trader.listSessions, {});
+  const [selectedSessionId, setSelectedSessionId] = useState<Id<'traderSessions'> | null>(null);
+
+  useEffect(() => {
+    if (!selectedSessionId && sessions && sessions.length > 0) {
+      setSelectedSessionId(sessions[0]._id);
+    }
+  }, [sessions, selectedSessionId]);
+
+  const logs = useQuery(api.trader.listLogs, {
+    sessionId: selectedSessionId ?? undefined,
+    limit: 120,
+  });
+  const positions = useQuery(api.trader.listPositions, {
+    sessionId: selectedSessionId ?? undefined,
+  });
+
+  const createSession = useMutation(api.trader.createSession);
+  const updateSession = useMutation(api.trader.updateSession);
+  const startSession = useMutation(api.trader.startSession);
+  const stopSession = useMutation(api.trader.stopSession);
+  const requestTick = useMutation(api.trader.requestImmediateTick);
+
+  const [formState, setFormState] = useState<FormState>(defaultForm);
+  const [isSubmitting, setSubmitting] = useState(false);
+  const [statusMessage, setStatusMessage] = useState<string | null>(null);
+
+  const selectedSession = useMemo(
+    () => sessions?.find((session) => session._id === selectedSessionId) ?? null,
+    [sessions, selectedSessionId],
+  );
+
+  const openPositions = useMemo(
+    () => positions?.filter((position) => position.status !== 'closed') ?? [],
+    [positions],
+  );
+
+  const handleInputChange = (event: ChangeEvent<HTMLInputElement>) => {
+    const { name, value } = event.target;
+    setFormState((previous) => ({
+      ...previous,
+      [name]: numericFields.includes(name as keyof FormState) ? Number(value) : value,
+    }));
+  };
+
+  const handleSubmit = async (event: FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    setSubmitting(true);
+    setStatusMessage(null);
+    try {
+      const sessionId = await createSession(formState);
+      setFormState(defaultForm);
+      setSelectedSessionId(sessionId);
+      setStatusMessage('Created a new trading session.');
+    } catch (error) {
+      setStatusMessage(formatError(error));
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
+  const applySelectedConfig = () => {
+    if (!selectedSession) return;
+    setFormState({
+      name: selectedSession.name,
+      instrument: selectedSession.instrument,
+      granularity: selectedSession.granularity,
+      shortWindow: selectedSession.shortWindow,
+      longWindow: selectedSession.longWindow,
+      tradeUnits: selectedSession.tradeUnits,
+      takeProfitMultiplier: selectedSession.takeProfitMultiplier,
+      stopLossMultiplier: selectedSession.stopLossMultiplier,
+      neutralThreshold: selectedSession.neutralThreshold,
+    });
+    setStatusMessage('Loaded configuration from the selected session. Use "Save changes" to persist.');
+  };
+
+  const handleSaveChanges = async () => {
+    if (!selectedSessionId) return;
+    setSubmitting(true);
+    setStatusMessage(null);
+    try {
+      await updateSession({ sessionId: selectedSessionId, config: formState });
+      setStatusMessage('Session configuration updated.');
+    } catch (error) {
+      setStatusMessage(formatError(error));
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
+  const performStart = async () => {
+    if (!selectedSessionId) return;
+    setStatusMessage(null);
+    try {
+      await startSession({ sessionId: selectedSessionId });
+      setStatusMessage('Session started. The agent will evaluate once per minute.');
+    } catch (error) {
+      setStatusMessage(formatError(error));
+    }
+  };
+
+  const performStop = async (closeOpen = true) => {
+    if (!selectedSessionId) return;
+    setStatusMessage(null);
+    try {
+      await stopSession({ sessionId: selectedSessionId, closePositions: closeOpen });
+      setStatusMessage(closeOpen ? 'Session stopped and flattening positions.' : 'Session stopped.');
+    } catch (error) {
+      setStatusMessage(formatError(error));
+    }
+  };
+
+  const performTick = async () => {
+    if (!selectedSessionId) return;
+    setStatusMessage(null);
+    try {
+      await requestTick({ sessionId: selectedSessionId });
+      setStatusMessage('Manual evaluation requested.');
+    } catch (error) {
+      setStatusMessage(formatError(error));
+    }
+  };
+
+  return (
+    <div className="w-full max-w-6xl mx-auto space-y-6">
+      <header className="bg-clay-800/70 text-white rounded-xl p-6 shadow-solid border border-clay-600">
+        <h1 className="text-4xl font-display tracking-wide mb-2">Autonomous OANDA Crypto Trader</h1>
+        <p className="text-lg text-clay-200 max-w-3xl">
+          Deploy a fully autonomous agent that monitors OANDA cryptocurrency markets, reacts to momentum
+          shifts, and manages positions automatically. Configure the risk model below, then start the
+          trader to let it run around the clock.
+        </p>
+      </header>
+
+      <div className="grid gap-6 lg:grid-cols-[2fr,3fr]">
+        <section className="space-y-6">
+          <div className="bg-clay-900/80 border border-clay-700 rounded-xl shadow-solid">
+            <header className="flex items-center justify-between px-6 py-4 border-b border-clay-700">
+              <h2 className="text-2xl text-white font-display">Trading Sessions</h2>
+              <button
+                className="text-sm text-clay-200 underline decoration-dotted hover:text-white"
+                onClick={() => setSelectedSessionId(null)}
+              >
+                Deselect
+              </button>
+            </header>
+            <div className="divide-y divide-clay-800">
+              {sessions && sessions.length > 0 ? (
+                sessions.map((session) => (
+                  <SessionListRow
+                    key={session._id}
+                    session={session}
+                    selected={selectedSessionId === session._id}
+                    onSelect={() => setSelectedSessionId(session._id)}
+                  />
+                ))
+              ) : (
+                <p className="p-6 text-clay-300">No sessions yet. Create one using the form below.</p>
+              )}
+            </div>
+            {selectedSession && (
+              <div className="px-6 py-4 border-t border-clay-800 space-y-4 text-sm text-clay-100">
+                <SelectedSessionSummary session={selectedSession} openPositions={openPositions} />
+                <div className="flex flex-wrap gap-3">
+                  <button className={actionButtonClasses} onClick={performStart}>
+                    Start session
+                  </button>
+                  <button className={actionButtonClasses} onClick={() => performStop(true)}>
+                    Stop &amp; close positions
+                  </button>
+                  <button className={actionButtonClasses} onClick={() => performStop(false)}>
+                    Stop (leave positions)
+                  </button>
+                  <button className={actionButtonClasses} onClick={performTick}>
+                    Evaluate now
+                  </button>
+                  <button className={actionButtonClasses} onClick={applySelectedConfig}>
+                    Load config into form
+                  </button>
+                  <button
+                    className={actionButtonClasses}
+                    onClick={handleSaveChanges}
+                    disabled={isSubmitting || !selectedSessionId}
+                  >
+                    Save changes
+                  </button>
+                </div>
+              </div>
+            )}
+          </div>
+
+          <form
+            className="bg-clay-900/80 border border-clay-700 rounded-xl shadow-solid p-6 space-y-4"
+            onSubmit={handleSubmit}
+          >
+            <h2 className="text-2xl text-white font-display">Configure a trading agent</h2>
+            <p className="text-sm text-clay-200">
+              Define the parameters for a new momentum-based trader. The agent uses dual moving averages to
+              detect directional bias and will open long or short positions accordingly.
+            </p>
+            <div className="grid gap-4 sm:grid-cols-2">
+              <LabeledInput
+                label="Session name"
+                name="name"
+                value={formState.name}
+                onChange={handleInputChange}
+              />
+              <LabeledInput
+                label="Instrument"
+                name="instrument"
+                value={formState.instrument}
+                onChange={handleInputChange}
+              />
+              <LabeledInput
+                label="Candle granularity"
+                name="granularity"
+                value={formState.granularity}
+                onChange={handleInputChange}
+              />
+              <LabeledInput
+                label="Short moving average"
+                name="shortWindow"
+                type="number"
+                min={1}
+                value={formState.shortWindow}
+                onChange={handleInputChange}
+              />
+              <LabeledInput
+                label="Long moving average"
+                name="longWindow"
+                type="number"
+                min={2}
+                value={formState.longWindow}
+                onChange={handleInputChange}
+              />
+              <LabeledInput
+                label="Units per trade"
+                name="tradeUnits"
+                type="number"
+                min={0.01}
+                step={0.01}
+                value={formState.tradeUnits}
+                onChange={handleInputChange}
+              />
+              <LabeledInput
+                label="Take profit multiplier"
+                name="takeProfitMultiplier"
+                type="number"
+                min={0.0001}
+                step={0.0001}
+                value={formState.takeProfitMultiplier}
+                onChange={handleInputChange}
+              />
+              <LabeledInput
+                label="Stop loss multiplier"
+                name="stopLossMultiplier"
+                type="number"
+                min={0.0001}
+                step={0.0001}
+                value={formState.stopLossMultiplier}
+                onChange={handleInputChange}
+              />
+              <LabeledInput
+                label="Neutral threshold"
+                name="neutralThreshold"
+                type="number"
+                min={0}
+                step={0.0001}
+                value={formState.neutralThreshold}
+                onChange={handleInputChange}
+              />
+            </div>
+            <div className="flex flex-wrap items-center gap-4">
+              <button className={actionButtonClasses} type="submit" disabled={isSubmitting}>
+                {isSubmitting ? 'Saving...' : 'Create new session'}
+              </button>
+              <button
+                className={actionButtonClasses}
+                type="button"
+                onClick={() => setFormState(defaultForm)}
+                disabled={isSubmitting}
+              >
+                Reset to defaults
+              </button>
+            </div>
+          </form>
+        </section>
+
+        <section className="bg-clay-900/80 border border-clay-700 rounded-xl shadow-solid flex flex-col">
+          <header className="px-6 py-4 border-b border-clay-700">
+            <h2 className="text-2xl text-white font-display">Agent activity log</h2>
+            <p className="text-sm text-clay-300">
+              Detailed trace of the trader&apos;s decisions, broker communication and analytics insights.
+            </p>
+          </header>
+          <div className="flex-1 overflow-y-auto max-h-[520px]">
+            {logs && logs.length > 0 ? (
+              <ul className="divide-y divide-clay-800">
+                {logs.map((log) => (
+                  <LogRow key={log._id} log={log} />
+                ))}
+              </ul>
+            ) : (
+              <p className="p-6 text-clay-300">Select a session to inspect its log output.</p>
+            )}
+          </div>
+        </section>
+      </div>
+
+      {statusMessage && (
+        <div className="bg-clay-800/90 border border-clay-600 text-clay-100 rounded-xl px-6 py-4 shadow-solid">
+          {statusMessage}
+        </div>
+      )}
+    </div>
+  );
+}
+
+type SessionListRowProps = {
+  session: SessionDoc;
+  selected: boolean;
+  onSelect: () => void;
+};
+
+function SessionListRow({ session, selected, onSelect }: SessionListRowProps) {
+  return (
+    <button
+      className={`w-full text-left px-6 py-4 transition-colors ${
+        selected ? 'bg-clay-800 text-white' : 'text-clay-200 hover:bg-clay-800/60'
+      }`}
+      onClick={onSelect}
+    >
+      <div className="flex items-center justify-between">
+        <div>
+          <p className="text-lg font-semibold">{session.name}</p>
+          <p className="text-sm text-clay-300">
+            {session.instrument} • {session.granularity} • Status: {session.status}
+          </p>
+        </div>
+        <div className="text-right text-sm text-clay-400">
+          <p>Last signal: {session.lastSignal}</p>
+          <p>
+            Last price: {session.lastPrice ? session.lastPrice.toFixed(5) : '—'}
+          </p>
+        </div>
+      </div>
+    </button>
+  );
+}
+
+type SelectedSessionSummaryProps = {
+  session: SessionDoc;
+  openPositions: PositionDoc[];
+};
+
+function SelectedSessionSummary({ session, openPositions }: SelectedSessionSummaryProps) {
+  return (
+    <div className="grid sm:grid-cols-2 gap-4 text-sm">
+      <div>
+        <h3 className="uppercase tracking-wide text-clay-400 text-xs mb-1">Performance</h3>
+        <p>Last evaluation: {session.lastEvaluationTime ? formatTime(session.lastEvaluationTime) : '—'}</p>
+        <p>
+          Last moving averages: {formatMaybeNumber(session.lastShortMA)} / {formatMaybeNumber(session.lastLongMA)}
+        </p>
+        <p>Neutral threshold: {(session.neutralThreshold * 100).toFixed(2)}%</p>
+      </div>
+      <div>
+        <h3 className="uppercase tracking-wide text-clay-400 text-xs mb-1">Open exposure</h3>
+        {openPositions.length > 0 ? (
+          <ul className="space-y-1">
+            {openPositions.map((position) => (
+              <li key={position._id}>
+                {position.direction.toUpperCase()} {position.units} @ {position.entryPrice.toFixed(5)}{' '}
+                {position.oandaTradeId ? `(#${position.oandaTradeId})` : '(paper)'}
+              </li>
+            ))}
+          </ul>
+        ) : (
+          <p>No open positions.</p>
+        )}
+      </div>
+    </div>
+  );
+}
+
+type LabeledInputProps = {
+  label: string;
+  name: keyof FormState;
+  value: string | number;
+  onChange: (event: ChangeEvent<HTMLInputElement>) => void;
+  type?: HTMLInputTypeAttribute;
+  min?: number;
+  step?: number;
+};
+
+function LabeledInput({ label, name, value, onChange, type = 'text', min, step }: LabeledInputProps) {
+  return (
+    <label className="flex flex-col text-sm text-clay-200 gap-1">
+      <span className="font-semibold text-clay-100">{label}</span>
+      <input
+        className="bg-clay-950/60 border border-clay-700 rounded-md px-3 py-2 text-white focus:outline-none focus:ring-2 focus:ring-clay-400"
+        name={name}
+        value={value}
+        onChange={onChange}
+        type={type}
+        min={min}
+        step={step}
+        required
+      />
+    </label>
+  );
+}
+
+type LogRowProps = {
+  log: LogDoc;
+};
+
+function LogRow({ log }: LogRowProps) {
+  const details = log.details ? formatDetails(log.details) : null;
+  return (
+    <li className="px-6 py-4 text-sm text-clay-100">
+      <div className="flex items-start justify-between gap-4">
+        <div>
+          <p className="font-semibold capitalize text-clay-200">{log.level}</p>
+          <p className="text-clay-100">{log.message}</p>
+          {details && <pre className="mt-2 bg-clay-950/60 rounded-lg p-3 text-xs overflow-x-auto">{details}</pre>}
+        </div>
+        <time className="text-xs text-clay-400">{formatTime(log.createdAt)}</time>
+      </div>
+    </li>
+  );
+}
+
+function formatMaybeNumber(value: number | undefined | null) {
+  if (value === undefined || value === null) return '—';
+  if (!Number.isFinite(value)) return String(value);
+  return value.toFixed(5);
+}
+
+function formatTime(timestamp: number) {
+  return new Date(timestamp).toLocaleString();
+}
+
+function formatDetails(details: unknown) {
+  try {
+    return typeof details === 'string' ? details : JSON.stringify(details, null, 2);
+  } catch (error) {
+    return String(details);
+  }
+}
+
+function formatError(error: unknown) {
+  if (error instanceof Error) return error.message;
+  try {
+    return JSON.stringify(error);
+  } catch {
+    return String(error);
+  }
+}


### PR DESCRIPTION
## Summary
- add Convex trading data models, cron scheduling, and broker utilities for OANDA integration
- implement server-side trading engine with session orchestration, order execution, and analytics
- build `/trader` dashboard UI to configure agents, monitor logs, and control live trading
- update landing page and README with links and setup guidance for the autonomous trader

## Testing
- npm run lint
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68ce113e2d888325b7e9a253d4619509